### PR TITLE
Removes screen overlay  with the pop-up menu

### DIFF
--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -107,6 +107,7 @@ $(function() {
     // Mouse has left, start the timer
     timer = setTimeout(function() {
       $hlinks.addClass('hidden');
+      $('.greedy-nav__toggle').removeClass('close');
     }, closingTime);
   }).on('mouseenter', function() {
     // Mouse is back, cancel the timer


### PR DESCRIPTION


<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.


## Summary

![1](https://user-images.githubusercontent.com/78736225/196153856-d696cda8-705f-4947-9549-adbb684f877e.png)

the pop up menu above disappears after you move the cursor out of it. However, the white overlay on the screen does not disappear, as well as the `x` nav button on the top-right, remains as is. 

Now when you click anywhere on the screen, the popup appears again, and the `x` nav button turns back to a hamburger menu button.
And when you click on the hamburger menu, the popup disappears. 

The functionality is now behaving in the exact opposite that we want to.

To remedy this, once the popup disappears the `x` nav button should also return back to normal (hamburger button)

This commit fixes this issue.

## Context

This is a direct pull request.

<!--
  Please confirm that you want to submit this Pull Request to Minimal Mistakes, the free Jekyll theme by Michael Rose, by deleting this comment block.
-->
